### PR TITLE
Small QOL changes

### DIFF
--- a/dlls/combat.cpp
+++ b/dlls/combat.cpp
@@ -525,6 +525,8 @@ void CBaseMonster::BecomeDead( void )
 
 	// make the corpse fly away from the attack vector
 	pev->movetype = MOVETYPE_TOSS;
+	// make the corpse non-solid to not block the player after death
+	pev->solid = SOLID_NOT;
 	//pev->flags &= ~FL_ONGROUND;
 	//pev->origin.z += 2;
 	//pev->velocity = g_vecAttackDir * -1;

--- a/pm_shared/pm_shared.c
+++ b/pm_shared/pm_shared.c
@@ -3022,11 +3022,11 @@ void PM_PlayerMove ( qboolean server )
 	}
 
 #if !defined( _TFC )
-	 // Slow down, I'm pulling it! (a box maybe) but only when I'm standing on ground
-	 if ( ( pmove->onground != -1 ) && ( pmove->cmd.buttons & IN_USE) && ( pmove->cmd.buttons & IN_BACK ) )
-	 {
-		 VectorScale( pmove->velocity, 0.3, pmove->velocity );
-	 }
+	// Slow down, I'm pulling it! (a box maybe) but only when I'm standing on ground
+	if ( ( pmove->onground != -1 ) && ( pmove->cmd.buttons & IN_USE) && ( pmove->cmd.buttons & IN_BACK ) )
+	{
+		VectorScale( pmove->velocity, 0.3, pmove->velocity );
+	}
 #endif
 
 	// Handle movement

--- a/pm_shared/pm_shared.c
+++ b/pm_shared/pm_shared.c
@@ -3022,11 +3022,11 @@ void PM_PlayerMove ( qboolean server )
 	}
 
 #if !defined( _TFC )
-	// Slow down, I'm pulling it! (a box maybe) but only when I'm standing on ground
-	if ( ( pmove->onground != -1 ) && ( pmove->cmd.buttons & IN_USE) )
-	{
-		VectorScale( pmove->velocity, 0.3, pmove->velocity );
-	}
+	 // Slow down, I'm pulling it! (a box maybe) but only when I'm standing on ground
+	 if ( ( pmove->onground != -1 ) && ( pmove->cmd.buttons & IN_USE) && ( pmove->cmd.buttons & IN_BACK ) )
+	 {
+		 VectorScale( pmove->velocity, 0.3, pmove->velocity );
+	 }
 #endif
 
 	// Handle movement


### PR DESCRIPTION
- [x] Enemy corpses block player movement until their death animation is done.
- [x] With `hud_fastswitch 1`, if there is more than one weapon for that slot there is still an extra action to select it.
- [x] Using the `use` key slows you down to `0.3` speed.
- [ ] Doors cannot be opened with the `use` key.
- [ ] Items cannot be picked up with the `use` key.